### PR TITLE
DM-44592: Remove ApTemplate from ap_pipe/ap_verify and docs

### DIFF
--- a/pipelines/ApTemplate.yaml
+++ b/pipelines/ApTemplate.yaml
@@ -1,5 +1,0 @@
-description: Stub Alert Production template building pipeline
-# This pipeline assumes the working repo has raws, calibs, refcats, and a skymap.
-
-imports:
-  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApTemplate.yaml


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Did you run `ap_verify.py` on this dataset?
- [x] If you made changes to `scripts/`, should those changes be propagated to [ap_verify_dataset_template](https://github.com/lsst-dm/ap_verify_dataset_template/), or are they specific to this data set?
- [x] Are the Sphinx documentation and readme up-to-date?
