### PR TITLE
DM-46341: Add readmes for script/ directory of ap_verify data sets

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,2 @@
-Copyright 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2022-2025 University of Washington
+Copyright 2024 CNRS/IN2P3

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Relevant Files and Directories
 path                  | description
 :---------------------|:-----------------------------
 `doc`                 | Contains Sphinx package documentation for the dataset. This documentation may be linked to from other packages, such as `ap_verify`.
-`etc`                 | Files necessary for reconstructing the repo (e.g. refcat yaml ingest files).
 `raw`                 | Raw ImSim exposures.
 `config`              | Dataset-specific configs to help the Science Pipelines work with this dataset, including the butler `export.yaml` file used by `ap_verify.py`
 `pipelines`           | To be populated with dataset-specific pipelines. Currently contains three example files specialized for ImSim data.
@@ -27,15 +26,16 @@ Butler Collections
 
 The butler repository in `preloaded/` contains the following collections; these may be chained collections containing arbitrarily-named runs.
 
-collection              | description
-:-----------------------|:-----------------------------
-`<instrument>/calib`    | Master calibration files for the data in the `raw` directory.
-`refcats`               | Level 7 HTM shards from relevant reference catalogs.
-`skymaps`               | Skymaps for the template coadds.
-`templates/<type>`      | Coadd images produced by a compatible version of the LSST pipelines. For example, `deepCoadd` images go in a `templates/deep` collection.
-`dia_catalogs`          | Catalogs representing the contents of the APDB at the start of each visit.
-`models`                | Pretrained machine learning models.
-`<instrument>/defaults` | A chained collection linking all of the above.
+collection               | description
+:------------------------|:-----------------------------
+`<instrument>/calib`     | Master calibration files for the data in the `raw` directory.
+`refcats`                | Level 7 HTM shards from relevant reference catalogs.
+`skymaps`                | Skymaps for the template coadds.
+`templates/<type>`       | Coadd images produced by a compatible version of the LSST pipelines. For example, `deepCoadd` images go in a `templates/deep` collection.
+`dia_catalogs`           | Catalogs representing the contents of the APDB at the start of each visit.
+`models`                 | Pretrained machine learning models.
+`fake-injection-catalog` | Pregenerated fake sources for completeness analysis.
+`<instrument>/defaults`  | A chained collection linking all of the above.
 
 Git LFS
 -------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+Dataset management scripts
+==========================
+
+This directory has  scripts for (re)creating the `ap_verify_ci_dc2` dataset.
+
+*Any* change to the repo requires running `make_preloaded_export.py` to ensure the export file is up-to-date.
+The data set will not run correctly without this step, but it also makes it easy to see and review each commit's changes.
+
+Most scripts are designed to be modular, and can be called either all at once (through `make_preloaded.sh`), or individually.
+However, `generate_fake_injection_catalog.sh` and `import_calibs.py` are not self-contained, and the user may need to manually edit chains before or after running them.
+See each script's docstring for usage instructions; those scripts that take arguments also support `--help`.
+
+Contents
+--------
+path                               | description
+:----------------------------------|:-----------------------------
+make_preloaded.sh                  | Rebuild everything from scratch.
+generate_fake_injection_catalog.sh | Create source injection catalogs in tract 4431. Requires templates.
+generate_self_preload.py           | Create preloaded APDB datasets by simulating a processing run with no pre-existing DIAObjects.
+get_nn_models.py                   | Transfer a selected pretrained model from an external repo (such as `repo/main`) and register it in `preloaded/`.
+get_refcats.py                     | Transfer refcats from an external repo (such as `repo/main`) and register them in `preloaded/`.
+import_calibs.py                   | Transfer calibs from an external repo (such as `repo/main`) and register them in `preloaded/`.
+import_templates.py                | Transfer templates from an external repo (such as `repo/main`) and register them in `preloaded/`.
+make_empty_preloaded_butler.sh     | Replace `preloaded/` with a repo containing only dimension definitions and standard "curated" calibs.
+make_preloaded_export.py           | Create an export file of `preloaded/` that's compatible with `butler import`.

--- a/scripts/generate_fake_injection_catalog.sh
+++ b/scripts/generate_fake_injection_catalog.sh
@@ -7,7 +7,7 @@ print_error() {
 
 usage() {
     print_error
-    print_error "Usage: $0 [-b BUTLER_REPO] -c ROOT_COLLECTION [-h]"
+    print_error "Usage: $0 [-b BUTLER_REPO] -o OUTPUT_COLLECTION [-h]"
     print_error
     print_error "Specific options:"
     print_error "   -b          Butler repo yaml file URI, defaults to preloaded repo"


### PR DESCRIPTION
This PR does some cleanups to the data set, and adds a readme giving a brief summary of all the maintenance scripts.

****

- [ ] Did you run `ap_verify.py` on this dataset?
- [ ] If you made changes to `scripts/`, should those changes be propagated to [ap_verify_dataset_template](https://github.com/lsst-dm/ap_verify_dataset_template/), or are they specific to this data set?
- [X] Are the Sphinx documentation and readme up-to-date?
